### PR TITLE
Show different background image for darkmode

### DIFF
--- a/src/theme/index.tsx
+++ b/src/theme/index.tsx
@@ -79,7 +79,11 @@ export function colors(darkMode: boolean): Colors {
     green1: '#27AE60',
     yellow1: '#FFE270',
     yellow2: '#F3841E',
-    blue1: '#2172E5'
+    blue1: '#2172E5',
+
+    bgUrl: darkMode
+      ? 'https://ipfs.io/ipfs/QmcCNnbT8UuAeM9CjoN1artmxxeKL7t2krBztCRvFEbdjN' 
+      : 'https://ipfs.io/ipfs/QmSoJw2uMHaK6bNZZbqSQ6xZ7b37P4oGm5YFHqLqWibygq'
 
     // dont wanna forget these blue yet
     // blue4: darkMode ? '#153d6f70' : '#C4D9F8',
@@ -218,7 +222,7 @@ html {
 export const ThemedGlobalStyle = createGlobalStyle`
 html {
   background-image:
-  url('https://ipfs.io/ipfs/QmcCNnbT8UuAeM9CjoN1artmxxeKL7t2krBztCRvFEbdjN');
+  url('${({ theme }) => theme.bgUrl }');
   background-position: 0;
   background-repeat: no-repeat;
   background-attachment: fixed;

--- a/src/theme/styled.d.ts
+++ b/src/theme/styled.d.ts
@@ -1,6 +1,7 @@
 import { FlattenSimpleInterpolation, ThemedCssFunction } from 'styled-components'
 
 export type Color = string
+export type Url = string
 export interface Colors {
   // base
   white: Color
@@ -44,6 +45,9 @@ export interface Colors {
   yellow1: Color
   yellow2: Color
   blue1: Color
+
+  // background image url
+  bgUrl: Url
 }
 
 export interface Grids {


### PR DESCRIPTION
Add bgImage property to Colors interface which gets set to either the light theme or dark theme depending on if the app is in dark mode. If there is a better way to do this, please leave a comment and I will address it in this PR.