### PR TITLE
Darkmode fixes

### DIFF
--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -65,7 +65,7 @@ export const ButtonPrimary = styled(Base)`
 
 export const ButtonLight = styled(Base)`
   background-color: ${({ theme }) => theme.primary1};
-  color: ${({ theme }) => theme.primaryText1};
+  color: white;
   font-size: 16px;
   font-weight: 500;
   &:focus {
@@ -73,7 +73,7 @@ export const ButtonLight = styled(Base)`
     background-color: ${({ theme, disabled }) => !disabled && darken(0.03, theme.primary5)};
   }
   &:hover {
-    background-color: ${({ theme, disabled }) => !disabled && darken(0.03, theme.primary5)};
+    background-color: ${({ theme, disabled }) => !disabled && darken(0.03, theme.primary1)};
   }
   &:active {
     box-shadow: 0 0 0 1pt ${({ theme, disabled }) => !disabled && darken(0.05, theme.primary5)};

--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -24,6 +24,7 @@ export const GreyCard = styled(Card)`
 
 export const OutlineCard = styled(Card)`
   border: 1px solid ${({ theme }) => theme.bg3};
+  color: ${({ theme }) => theme.text1};
 `
 
 export const YellowCard = styled(Card)`

--- a/src/pages/Earn/index.tsx
+++ b/src/pages/Earn/index.tsx
@@ -13,6 +13,8 @@ import { JSBI } from '@uniswap/sdk'
 import { BIG_INT_ZERO } from '../../constants'
 import { OutlineCard } from '../../components/Card'
 const PageWrapper = styled(AutoColumn)`
+  background-color: ${({theme}) => theme.bg1};
+  border-radius: 15px;
   max-width: 640px;
   width: 100%;
 `

--- a/src/pages/Pool/index.tsx
+++ b/src/pages/Pool/index.tsx
@@ -21,6 +21,8 @@ import { Dots } from '../../components/swap/styleds'
 import { CardSection, DataCard, CardNoise, CardBGImage } from '../../components/earn/styled'
 
 const PageWrapper = styled(AutoColumn)`
+  background-color: ${({theme}) => theme.bg1};
+  border-radius: 15px;
   max-width: 640px;
   width: 100%;
 `


### PR DESCRIPTION
Standardized styling for "Connect Wallet" button to match other styles.
Corrected the background for both the Pool and Staking pages to match the bg1 from the theme object
<img width="1432" alt="Screen Shot 2021-01-18 at 7 53 50 PM" src="https://user-images.githubusercontent.com/59103702/104978311-36f01600-59c7-11eb-9ab1-a870acde0c57.png">
<img width="1433" alt="Screen Shot 2021-01-18 at 7 53 55 PM" src="https://user-images.githubusercontent.com/59103702/104978327-3d7e8d80-59c7-11eb-9d29-51e025ed54b3.png">
<img width="1429" alt="Screen Shot 2021-01-18 at 7 54 12 PM" src="https://user-images.githubusercontent.com/59103702/104978347-4707f580-59c7-11eb-9898-7ed017d0e1bf.png">


.
