### PR TITLE
Add 'About Penguin Party' Page

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -311,6 +311,9 @@ export default function Header() {
           <StyledNavLink id={`stake-nav-link`} to={'/vote'}>
             🦄 Voting 🦄
           </StyledNavLink>
+          <StyledNavLink id={`about-nav-link`} to={'/about'}>
+          🐧 About Penguin Party 🐧
+          </StyledNavLink>
         </HeaderLinks>
       </HeaderRow>
       <HeaderControls>

--- a/src/pages/AboutTheTeam/index.tsx
+++ b/src/pages/AboutTheTeam/index.tsx
@@ -1,0 +1,141 @@
+import React from 'react';
+import styled from 'styled-components'
+import PinkLogo from '../../../src/assets/svg/logo_pink.svg'
+import './style.css'
+
+
+export default function ShowTeamPage() {
+  const PenguinParty = styled.div`
+  display: flex;
+  justify-content: space-around;
+  margin-top: -10%;
+  background: rgba(0, 0, 0, 0.6);
+  `
+  const AboutText = styled.div`
+  align-self: center;
+  color: white;
+  margin: 5%;
+  padding: 2%;
+  `
+
+  const PenguinArea = styled.div`
+  background: rgba(0, 0, 0, 0.6);
+  color: white;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  text-align: center;
+  `
+
+  const Hiturunk = styled.div`
+  background: rgba(0, 0, 0, 0.6);
+  color: white;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-evenly;
+  text-align: center;
+  align-items: center;
+  `
+  const Devs = styled.div`
+  background: rgba(0, 0, 0, 0.6);
+  background-position: cover;
+  color: white;
+  width: 100%;
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr 1fr;
+  flex-wrap: wrap;
+  place-items: center;
+  text-align: center;
+  margin: 0 auto;
+  `
+  const Partners = styled.div`
+  background: rgba(0, 0, 0, 0.6);
+  background-position: cover;
+  color: white;
+  text-align: center;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  padding-bottom: 5%;
+  `
+  
+  
+
+  return (
+    <>
+      <PenguinParty className='penguin-party'>
+      <img width={'35%'} height={'35%'} src={'https://miro.medium.com/max/1200/1*fYXGqcTgQldOd7687sHDag.gif'} alt="logo" style={{'margin': "5%", 'paddingLeft': "2%"}} />
+      <AboutText>
+        <h2><b>Penguin Party</b> is a Decentralized Governance Token Delegation focused on software deliverables to improve decentralized protocols and ensure protocol interoperability.</h2>
+      <h2><b>Penguin Swap</b> is our front-end interface which interacts with the Uniswap trading Protocol contracts using Penguin Swap's preferred token list and custom token / routing pairs.  </h2>
+      </AboutText>
+    </PenguinParty>
+    <PenguinArea>
+    <Hiturunk>
+    <h1>The 🐧 Team</h1>
+      <img className='hiturunk' src="https://pbs.twimg.com/profile_images/1316829704868040707/wZd46uDZ_400x400.jpg" alt=""/>
+      <h2>Hiturunk</h2>
+      <h3>Senior Developer / CEO</h3>
+    </Hiturunk>
+    <Devs className='devs'>
+      <div className='dev'>
+    <img className='team-photo' src={PinkLogo} alt=""/>
+    <h2>Dwi</h2>
+    <h3>Senior Developer / CTO</h3>
+      </div>
+      <div className='dev'>
+    <img className='team-photo' src={PinkLogo} alt=""/>
+    <h2>Pancake</h2>
+    <h3>Senior Developer</h3>
+      </div>
+      <div className='dev'>
+    <img className='team-photo' src={PinkLogo} alt=""/>
+    <h2>Stephen</h2>
+    <h3>Senior Developer</h3>
+      </div>
+      <div className='dev'>
+    <img className='team-photo' src={PinkLogo} alt=""/>
+    <h2>Pooryia</h2>
+    <h3>Graphics and Logo Designer</h3>
+      </div>
+      <div className='dev'>
+    <img className='team-photo' src={PinkLogo} alt=""/>
+    <h2>Davey</h2>
+    <h3>Statistics/Machine Learning</h3>
+      </div>
+      <div className='dev'>
+    <img className='team-photo' src={PinkLogo} alt=""/>
+    <h2>RyanG</h2>
+    <h3>Junior Developer</h3>
+      </div>
+      <div className='dev'>
+    <img className='team-photo' src={PinkLogo} alt=""/>
+    <h2>Finagle</h2>
+    <h3>Junior Developer</h3>
+      </div>
+      <div className='dev'>
+    <img className='team-photo' src={PinkLogo} alt=""/>
+    <h2>Dreadful</h2>
+    <h3>Junior Developer</h3>
+      </div>
+    </Devs>
+    <Partners>
+    <h1>Our 🐧 Partners</h1>
+    <div className='lid-cryptoKek'>
+    <div className='lid-div'>
+    <a href="https://lid.sh/"><img className='lid-pic' src="https://cryptoslate.com/wp-content/uploads/2020/08/lid-social.jpg" alt=""/></a>
+      <h2><a href="https://lid.sh/">Liquidity Dividends Protocol</a></h2>
+      <h3>The LID token by Liquidity Dividends Protocol allows stakers to earn rewards from bots trading on Uniswap while gaining exposure to the wide variety of assets paired against LID as locked liquidity. </h3>
+    </div>
+    <div className='crypto-kek-div'>
+    <a href="https://cryptokek.com/"><img className='crypto-kek-pic' src="https://pbs.twimg.com/profile_images/1353739226748223488/-J29E6vO_400x400.png" alt=""/></a>
+      <h2><a href="https://cryptokek.com/">CryptoKek</a></h2>
+      <h3>CryptoKek is an analytics platform for decentralized exchanges designed to offer cutting edge insight to support its users in their endeavors. </h3>
+    </div>
+    </div>
+    </Partners>
+    </PenguinArea>
+    </>
+  )
+}

--- a/src/pages/AboutTheTeam/style.css
+++ b/src/pages/AboutTheTeam/style.css
@@ -1,0 +1,82 @@
+
+body {
+  background: rgba(0, 0, 0, 0.5);
+  background-size: cover;
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  width: 100%;
+ 
+}
+.crypto-kek-div {
+  margin-right: 2%;
+}
+
+.dev {
+  margin: 2%
+}
+
+.devs h1 {
+  margin: auto;
+}
+
+.hiturunk {
+  width: 225px;
+  border-radius: 50%;
+}
+
+.img-div {
+  margin: 0 auto;;
+}
+
+.lid-div {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  margin: 0 auto;
+  margin-left: 2%;
+}
+
+.lid-cryptoKek {
+  display: flex;
+  padding-bottom: 5%;
+  margin-top: 3%;
+  margin-bottom: 5%;
+}
+
+.lid-pic {
+  width: 275px;
+  border-radius: 10px;
+}
+
+.team-photo {
+  width: 150px;
+  height: 150px;
+  grid-row-start: 1;
+}
+
+@media (max-width: 767px) {
+  .lid-cryptoKek {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .penguin-party{
+    
+      flex-direction: column;
+      align-items: center;
+      text-align: center;
+    }
+    .devs {
+      flex-direction: column;
+      grid-template-columns: 1fr 1fr;
+    }
+  
+    .lid-pic {
+      width: 100%;
+    }
+   .hiturunk {
+     width: 45%;
+   }
+  }

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -31,7 +31,7 @@ import { OpenClaimAddressModalAndRedirectToSwap, RedirectPathToSwapOnly, Redirec
 
 import Vote from './Vote'
 import VotePage from './Vote/VotePage'
-
+import ShowTeamPage from './AboutTheTeam'
 const AppWrapper = styled.div`
   display: flex;
   flex-flow: column;
@@ -112,6 +112,7 @@ export default function App() {
               <Route exact strict path="/migrate/v1/:address" component={MigrateV1Exchange} />
               <Route exact strict path="/uni/:currencyIdA/:currencyIdB" component={Manage} />
               <Route exact strict path="/vote/:id" component={VotePage} />
+              <Route exact path="/about" component={ShowTeamPage} />
               <Route component={RedirectPathToSwapOnly} />
             </Switch>
           </Web3ReactManager>


### PR DESCRIPTION
This commit adds the About Penguin Party page to the project. Included is information about the project, the team, and partners.
<img width="1440" alt="Screen Shot 2021-03-10 at 11 14 32 PM" src="https://user-images.githubusercontent.com/59103702/110739472-e04cce80-81f6-11eb-8df3-7cfc75593326.png">
![pp2](https://user-images.githubusercontent.com/59103702/110739486-e6db4600-81f6-11eb-8c23-4f48efe95ae6.png)
<img width="1440" alt="Screen Shot 2021-03-10 at 11 16 29 PM" src="https://user-images.githubusercontent.com/59103702/110739498-ed69bd80-81f6-11eb-80a6-16afd3959c4c.png">
<img width="1440" alt="Screen Shot 2021-03-10 at 11 16 52 PM" src="https://user-images.githubusercontent.com/59103702/110739524-f9557f80-81f6-11eb-9498-32518c4babc3.png">
