### PR TITLE
Updates / Bug Fixes (usdc price, token analytics)

### DIFF
--- a/src/.parsed-git.json
+++ b/src/.parsed-git.json
@@ -1,1 +1,1 @@
-{"git_commit_hash":"b1c858f18bb5d1deb5217f7dba027266b1365acb","git_branch":"master"}
+{"git_commit_hash":"ec9f77031ea543ff43d70a37e5458a995ba86d13","git_branch":"master"}

--- a/src/components/Header/UniBalanceContent.tsx
+++ b/src/components/Header/UniBalanceContent.tsx
@@ -34,6 +34,10 @@ const StyledClose = styled(X)`
   }
 `
 
+const AnalyticsLink = styled(ExternalLink)`
+color: white;
+`
+
 /**
  * Content for balance stats modal
  */
@@ -121,16 +125,16 @@ export default function UniBalanceContent({ setShowUniBalanceModal }: { setShowU
               <TYPE.white color="white">⛩{totalSupplyTori?.toFixed(0, { groupSeparator: ',' })}⛩ - ${toriPrice?.toFixed(2) ?? '-'} / ⛩</TYPE.white>
             </RowBetween>
             {uni && uni.chainId === ChainId.MAINNET ? (
-              <ExternalLink href={`https://uniswap.info/token/${uni.address}`}>View 🐟 Analytics</ExternalLink>
+              <AnalyticsLink href={`https://uniswap.info/token/${uni.address}`}>View 🐟 Analytics</AnalyticsLink>
             ) : null}
             {shrimp && shrimp.chainId === ChainId.MAINNET ? (
-              <ExternalLink href={`https://uniswap.info/token/${shrimp.address}`}>View 🦐 Analytics</ExternalLink>
+              <AnalyticsLink href={`https://uniswap.info/token/${shrimp.address}`}>View 🦐 Analytics</AnalyticsLink>
             ) : null}
             {crab && crab.chainId === ChainId.MAINNET ? (
-              <ExternalLink href={`https://uniswap.info/token/${crab.address}`}>View 🦀 Analytics</ExternalLink>
+              <AnalyticsLink href={`https://uniswap.info/token/${crab.address}`}>View 🦀 Analytics</AnalyticsLink>
             ) : null}
             {tori && tori.chainId === ChainId.MAINNET ? (
-              <ExternalLink href={`https://uniswap.info/token/${tori.address}`}>View ⛩ Analytics</ExternalLink>
+              <AnalyticsLink href={`https://uniswap.info/token/${tori.address}`}>View ⛩ Analytics</AnalyticsLink>
             ) : null}
           </AutoColumn>
         </CardSection>

--- a/src/components/Web3Status/index.tsx
+++ b/src/components/Web3Status/index.tsx
@@ -88,7 +88,7 @@ const Web3StatusConnect = styled(Web3StatusGeneric)<{ faded?: boolean }>`
 const Web3StatusConnected = styled(Web3StatusGeneric)<{ pending?: boolean }>`
   background-color: ${({ pending, theme }) => (pending ? theme.primary1 : theme.bg2)};
   border: 1px solid ${({ pending, theme }) => (pending ? theme.primary1 : theme.bg3)};
-  color: ${({ pending, theme }) => (pending ? theme.white : theme.text1)};
+  color: ${({ pending, theme }) => (pending ? theme.text1 : theme.text1)};
   font-weight: 500;
   :hover,
   :focus {
@@ -185,7 +185,7 @@ function Web3StatusInner() {
       <Web3StatusConnected id="web3-status-connected" onClick={toggleWalletModal} pending={hasPendingTransactions}>
         {hasPendingTransactions ? (
           <RowBetween>
-            <Text>{pending?.length} Pending</Text> <Loader stroke="white" />
+            <Text>{pending?.length} Pending</Text> <Loader stroke='black' />
           </RowBetween>
         ) : (
           <>

--- a/src/components/swap/AdvancedSwapDetails.tsx
+++ b/src/components/swap/AdvancedSwapDetails.tsx
@@ -10,6 +10,12 @@ import QuestionHelper from '../QuestionHelper'
 import { RowBetween, RowFixed } from '../Row'
 import FormattedPriceImpact from './FormattedPriceImpact'
 import SwapRoute from './SwapRoute'
+// import { useActiveWeb3React } from '../../hooks'
+import useUSDCPrice from '../../utils/useUSDCPrice'
+// import { UNI } from '../../constants'
+
+
+
 
 const InfoLink = styled(ExternalLink)`
   width: 100%;
@@ -26,10 +32,29 @@ function TradeSummary({ trade, allowedSlippage }: { trade: Trade; allowedSlippag
   const { priceImpactWithoutFee, realizedLPFee } = computeTradePriceBreakdown(trade)
   const isExactIn = trade.tradeType === TradeType.EXACT_INPUT
   const slippageAdjustedAmounts = computeSlippageAdjustedAmounts(trade, allowedSlippage)
+  // const { chainId } = useActiveWeb3React()
+  const inputAmount = trade.inputAmount.currency
+  const usdcInputPrice = useUSDCPrice(inputAmount)
 
+  
+
+  
   return (
     <>
       <AutoColumn style={{ padding: '0 16px' }}>
+        <RowBetween>
+          <RowFixed>
+          <TYPE.black fontSize={14} fontWeight={400} color={theme.text2}>
+            {'USDC Price'}
+            </TYPE.black>
+            <QuestionHelper text="This is the value of your trade in USDC" />
+          </RowFixed>
+          <RowFixed>
+          <TYPE.black fontSize={14} fontWeight={400} color={theme.text2}>
+          {'$'+usdcInputPrice?.toFixed(2)}
+          </TYPE.black>
+          </RowFixed>
+        </RowBetween>
         <RowBetween>
           <RowFixed>
             <TYPE.black fontSize={14} fontWeight={400} color={theme.text2}>
@@ -38,7 +63,7 @@ function TradeSummary({ trade, allowedSlippage }: { trade: Trade; allowedSlippag
             <QuestionHelper text="Your transaction will revert if there is a large, unfavorable price movement before it is confirmed." />
           </RowFixed>
           <RowFixed>
-            <TYPE.black color={theme.text1} fontSize={14}>
+            <TYPE.black color={theme.text1} fontSize={14}> 
               {isExactIn
                 ? `${slippageAdjustedAmounts[Field.OUTPUT]?.toSignificant(4)} ${trade.outputAmount.currency.symbol}` ??
                   '-'

--- a/src/components/swap/AdvancedSwapDetails.tsx
+++ b/src/components/swap/AdvancedSwapDetails.tsx
@@ -45,9 +45,9 @@ function TradeSummary({ trade, allowedSlippage }: { trade: Trade; allowedSlippag
         <RowBetween>
           <RowFixed>
           <TYPE.black fontSize={14} fontWeight={400} color={theme.text2}>
-            {'USDC Price'}
+            {'Token A Price in USDC'}
             </TYPE.black>
-            <QuestionHelper text="This is the value of your trade in USDC" />
+            <QuestionHelper text="This is the value of token A in USDC" />
           </RowFixed>
           <RowFixed>
           <TYPE.black fontSize={14} fontWeight={400} color={theme.text2}>

--- a/src/pages/AboutTheTeam/index.tsx
+++ b/src/pages/AboutTheTeam/index.tsx
@@ -121,7 +121,7 @@ export default function ShowTeamPage() {
       <div className='dev'>
     <img className='team-photo' src={PinkLogo} alt=""/>
     <h2>Dreadful</h2>
-    <h3>Senior Developer</h3>
+    <h3>Developer</h3>
       </div>
     </Devs>
     <Partners>

--- a/src/state/stake/hooks.ts
+++ b/src/state/stake/hooks.ts
@@ -216,7 +216,7 @@ export function useStakingInfo(pairToFilterBy?: Pair | null): StakingInfo[] {
 
 export function useTotalUniEarned(): TokenAmount | undefined {
   const { chainId } = useActiveWeb3React()
-  const uni = chainId ? UNI[chainId] : undefined
+  const uni = chainId ? FISH : undefined
   const stakingInfos = useStakingInfo()
 
   return useMemo(() => {


### PR DESCRIPTION
- Allows for the USDC price display in the swap info 
- FISH token contract stats to now displayed when the user clicks the 'fish' icon. Page no longer refreshes after user clicks icon, and errors are no longer present.